### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "haskell"
+run = "ghci Main.hs"

--- a/README.md
+++ b/README.md
@@ -2,3 +2,5 @@ SCMF-DSL
 ========
 
 Implementation of SCMF conventions and principles in Haskell as a class project for CS519 (Domain Specific Languages) class
+
+[![Run on Repl.it](https://repl.it/badge/github/altern/SCMF-DSL)](https://repl.it/github/altern/SCMF-DSL)


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@altern/SCMF-DSL).